### PR TITLE
Added live game form, round switching logic, save scores functionality

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -1,5 +1,24 @@
 {
   "teams": [],
   "players": [],
-  "scores": []
+  "scores": [
+    {
+      "teamID": 1,
+      "teamScore": 0,
+      "date": "2021-02-01T17:00:20.673Z",
+      "id": 1
+    },
+    {
+      "teamID": 3,
+      "teamScore": 0,
+      "date": "2021-02-01T17:00:20.673Z",
+      "id": 2
+    },
+    {
+      "teamID": 2,
+      "teamScore": 0,
+      "date": "2021-02-01T17:00:20.673Z",
+      "id": 3
+    }
+  ]
 }

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>Trunceons and Flagons</title>
+        <title>Truncheons and Flagons</title>
         <link rel="stylesheet" href="./styles/main.css">
     </head>
 
@@ -17,3 +17,4 @@
         <script type="module" src="./scripts/main.js"></script>
     </body>
 </html>
+

--- a/scripts/game/LiveGameForm.js
+++ b/scripts/game/LiveGameForm.js
@@ -1,0 +1,119 @@
+const bannerElement = document.querySelector(".banner")
+const formElement = document.querySelector('.form')
+const eventHub = document.querySelector('#container')
+
+// Keep track of current round and scores
+
+let currentRound = 1;
+let team1Score = 0;
+let team2Score = 0;
+let team3Score = 0;
+
+//dummy Data for teamIDs
+const team1ID = 1;
+const team2ID = 2;
+const team3ID = 3;
+
+//HTML for a live game, dynamic with current round number
+const LiveGameForm = (round) => {
+    return `
+    <form action="" class="liveGameForm">
+    <article class='scoreCard'>
+        <div class="scoreCard__col teamNames">
+            <h3 class="scoreCard__banner--teams">Teams</h3>
+            <p id="scoreCard__team1--name">Jim-Jams</p>
+            <p id="scoreCard__team2--name">Flimpies</p>
+            <p id="scoreCard__team3--name">Charmanders</p>
+        </div>
+        <div class="scoreCard__col teamRoles">
+            <h3 class="scoreCard__banner--roles">Current Role</h3>
+            <p id="scoreCard__team1--role">Knights</p>
+            <p id="scoreCard__team2--role">Fairies</p>
+            <p id="scoreCard__team3--role">Goblins</p>
+        </div>
+        <div class="scoreCard__col teamScores">
+            <h3 class="scoreCard__banner--scores">Enter your round score:</h3>
+            <input type="number" name="team1Score" id="team1Score" value="0">
+            <input type="number" name="team2Score" id="team2Score" value="0">
+            <input type="number" name="team3Score" id="team3Score" value="0">
+        </div>
+    </article>
+    <button id="endRound">${round === 3 ? "End Game" : "End Round " + round}</button>
+</form>`
+}
+
+// This function replaces the ".form" section with a live game.
+
+// This will need to know teamIDs. If no round parameter is passed in, it'll default as round 1
+export const LiveGame = (round = 1) => {
+    currentRound = round
+    bannerElement.innerHTML = `Round ${round}`
+    const liveGameForm = LiveGameForm(round)
+    render(liveGameForm)
+}
+
+const render = (liveGameForm) => {
+    formElement.innerHTML = liveGameForm
+}
+
+/* Logic for how to handle each "endRound" click, including 
+updating the current scores and moving to the next round 
+or ending the game, saving the score, and going home */
+
+eventHub.addEventListener("click", e => {
+    if (e.target.id === "endRound") {
+        e.preventDefault()
+        if (currentRound === 1){
+            calculateScores()
+            logScores()
+            LiveGame(2)
+        } else if (currentRound === 2) {
+            calculateScores()
+            logScores()
+            LiveGame(3)
+        } else if (currentRound === 3) {
+            calculateScores()
+            logScores()
+            saveScores()
+            goHome()
+        }
+    }
+})
+
+// grabbing score from inputs and adding to team score, parsing to integer from HTML
+const calculateScores = () => {
+    team1Score += parseInt(document.getElementById("team1Score").value)
+    team2Score += parseInt(document.getElementById("team2Score").value)
+    team3Score += parseInt(document.getElementById("team3Score").value)
+}
+
+// just for testing purposes, delete later
+
+const logScores = () => {
+    console.log("Team 1 score is " + team1Score)
+    console.log("Team 2 score is " + team2Score)
+    console.log("Team 3 score is " + team3Score)
+}
+
+// dispatch "appStateDefault"
+
+const goHome = () => {
+    const customEvent = new CustomEvent("appStateDefault")
+    eventHub.dispatchEvent(customEvent)
+}
+
+// dispatch "saveScoresRequested" event with team & score data
+
+const saveScores = () => {
+    const customEvent = new CustomEvent("saveScoresRequested", {
+        detail: {
+            team1ID: team1ID,
+            team1Score: team1Score,
+            team2ID: team2ID,
+            team2Score: team2Score,
+            team3ID: team3ID,
+            team3Score: team3Score
+        }
+    })
+    eventHub.dispatchEvent(customEvent)
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,8 +1,11 @@
 
 import { GameSetup } from './game/GameSetupForm.js'
+import { LiveGame } from './game/LiveGameForm.js';
 import "./players/PlayerForm.js"
 import './teams/TeamForm.js'
+import './scores/ScoreDataProvider.js'
 
 console.log("Welcome to the main module")
 
-GameSetup();
+// GameSetup();
+LiveGame();

--- a/scripts/scores/Score.js
+++ b/scripts/scores/Score.js
@@ -1,0 +1,7 @@
+export const Score = (teamID, teamScore) => {
+    return {
+        teamID: teamID,
+        teamScore: teamScore,
+        date: new Date()
+    }
+}

--- a/scripts/scores/ScoreDataProvider.js
+++ b/scripts/scores/ScoreDataProvider.js
@@ -1,0 +1,33 @@
+import { Score } from './Score.js'
+const eventHub = document.querySelector('#container')
+
+let scoreCollection = [];
+
+export const getScores = () => {
+    fetch("http://localhost:8088/scores")
+        .then(res => res.json())
+        .then(parsedScore => {
+            scoreCollection = parsedScore
+        })
+}
+
+const saveScore = (score) => {
+    fetch("http://localhost:8088/scores", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+          },
+        body: JSON.stringify(score)
+    })
+}
+
+
+eventHub.addEventListener("saveScoresRequested", e => {
+    const gameScore = e.detail
+    const team1Score = Score(gameScore.team1ID, gameScore.team1Score)
+    const team2Score = Score(gameScore.team2ID, gameScore.team2Score)
+    const team3Score = Score(gameScore.team3ID, gameScore.team3Score)
+    saveScore(team1Score)
+    saveScore(team2Score)
+    saveScore(team3Score)
+})

--- a/styles/forms.css
+++ b/styles/forms.css
@@ -7,3 +7,26 @@
 .setupForm {
     border: 1px dotted blue;
 }
+
+.scoreCard  {
+    display: flex;
+    justify-content: space-evenly;
+    margin-top: 10px;
+}
+
+.scoreCard__col {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.liveGameForm {
+    border: 1px dotted blue;
+    display: flex;
+    flex-direction: column;
+}
+
+#endRound {
+    margin-top: 10px;
+    align-self: flex-end;
+}


### PR DESCRIPTION
# Description

This probably does too much for one pull request, sorry about that.

This:
- [ ] Adds the "Live Game" form
- [ ] Handles the logic for which round we're on, dynamically changing header and button
- [ ] Keeps track of the score between rounds
- [ ] saves scores at the end of the game


# Testing Instructions

`git fetch --all`
`git checkout ram-create-live-game-form`
`serve`
Also, launch the API server

Test:
- [ ] App launches in "live game mode"
- [ ] You can add scores, says "round 1", button says "End Round 1"
- [ ] Clicking "End Round" button resets scores to 0 and moves to next round"
- [ ] On round 3, button says "End Game"
- [ ] On "End Game", scores are saved to API and app resets to "Game Setup" / home state