### PR TITLE
Connected setup and live game forms, passing team IDs to the live gam…

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -17,24 +17,5 @@
     }
   ],
   "players": [],
-  "scores": [
-    {
-      "teamID": 1,
-      "teamScore": 0,
-      "date": "2021-02-01T17:00:20.673Z",
-      "id": 1
-    },
-    {
-      "teamID": 3,
-      "teamScore": 0,
-      "date": "2021-02-01T17:00:20.673Z",
-      "id": 2
-    },
-    {
-      "teamID": 2,
-      "teamScore": 0,
-      "date": "2021-02-01T17:00:20.673Z",
-      "id": 3
-    }
-  ]
+  "scores": []
 }

--- a/scripts/game/GameSetupForm.js
+++ b/scripts/game/GameSetupForm.js
@@ -61,12 +61,19 @@ eventHub.addEventListener("click", e => {
 eventHub.addEventListener("click", e => {
     if (e.target.id === "startGame") {
         e.preventDefault()
-        const team1 = document.querySelector("#team1Select").value
-        const team2 = document.querySelector("#team2Select").value
-        const team3 = document.querySelector("#team3Select").value
+        const team1 = parseInt(document.querySelector("#team1Select").value)
+        const team2 = parseInt(document.querySelector("#team2Select").value)
+        const team3 = parseInt(document.querySelector("#team3Select").value)
         if (allTeamsChosen(team1, team2, team3)) {
             if (areUnique(team1, team2, team3)) {
-                alert("Ready to go!")
+                const cE = new CustomEvent("startNewGame", {
+                    detail: {
+                        team1ID: team1,
+                        team2ID: team2,
+                        team3ID: team3,
+                    }
+                })
+                eventHub.dispatchEvent(cE)
             } else {
                 alert("Teams cannot play themselves. Well, not easily, anyway.")
             }

--- a/scripts/game/LiveGameForm.js
+++ b/scripts/game/LiveGameForm.js
@@ -10,11 +10,13 @@ let team2Score = 0;
 let team3Score = 0;
 
 //dummy Data for teamIDs
-const team1ID = 1;
-const team2ID = 2;
-const team3ID = 3;
+let team1ID = 0;
+let team2ID = 0;
+let team3ID = 0;
 
 //HTML for a live game, dynamic with current round number
+
+// We need to dynamically rotate the team roles each round
 const LiveGameForm = (round) => {
     return `
     <form action="" class="liveGameForm">
@@ -45,7 +47,7 @@ const LiveGameForm = (round) => {
 // This function replaces the ".form" section with a live game.
 
 // This will need to know teamIDs. If no round parameter is passed in, it'll default as round 1
-export const LiveGame = (round = 1) => {
+const LiveGame = (round = 1) => {
     currentRound = round
     bannerElement.innerHTML = `Round ${round}`
     const liveGameForm = LiveGameForm(round)
@@ -117,3 +119,10 @@ const saveScores = () => {
     })
     eventHub.dispatchEvent(customEvent)
 }
+
+eventHub.addEventListener("startNewGame", e => {
+    team1ID = e.detail.team1ID
+    team2ID = e.detail.team2ID
+    team3ID = e.detail.team3ID
+    LiveGame()
+})

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,6 @@
 
 import { GameSetup } from './game/GameSetupForm.js'
-import { LiveGame } from './game/LiveGameForm.js';
+import './game/LiveGameForm.js';
 import "./players/PlayerForm.js"
 import './teams/TeamForm.js'
 import './scores/ScoreDataProvider.js'
@@ -8,5 +8,4 @@ import './scores/ScoreDataProvider.js'
 
 console.log("Welcome to the main module")
 
-// GameSetup();
-LiveGame();
+GameSetup();


### PR DESCRIPTION

# Description
Connected setup and live game forms

# Changes
- [ ] App starts up on setup form again
- [ ] Choosing 3 different teams and clicking "Start A Game" passes those 3 team IDs to the "live game" app state
- [ ] Recorded scores now include the dynamic "team ID" pulled from the value of the team select in the setup page

# Testing Instructions
`git fetch --all`
`git checkout ram-connect-setup-and-live-game`
serve and API serve

# Checklist:
- [ ] Clicking "start a game" now brings you to the "live game" state
- [ ] Clicking "End game" now records 3 score objects in the database with teamIDs based on the "game setup form" team selects