### PR TITLE
Remove comma after last player on leaderboards

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -97,7 +97,7 @@
       "id": 7
     },
     {
-      "firstName": "Michelin ",
+      "firstName": "Michelin",
       "lastName": "Man",
       "country": "Canada",
       "teamId": 3,

--- a/scripts/game/GameSetupForm.js
+++ b/scripts/game/GameSetupForm.js
@@ -67,10 +67,9 @@ const GameSetupTable = () => {
 
             let leaderboardsTableData = `
             ${teamsWithScores.map(team => {
+                const prettyPlayers = team.players.map(player => player.firstName).join(", ")
                 return `
-                <tr><td><div class="scoreboard__teamName">${team.teamName}</div> players : ${team.players.map(player =>{
-                    return `${player.firstName}, `
-                }).join("")}</td><td>${team.totalScore}</td></tr>
+                <tr><td><div class="scoreboard__teamName">${team.teamName}</div> players : ${prettyPlayers}</td><td>${team.totalScore}</td></tr>
                 `
             }).join("")}
             `


### PR DESCRIPTION
# Bug Fix
- [ ] Players in the leaderboard are now seperated by ", " without a comma after the last player